### PR TITLE
Load env variables from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+FINNHUB_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,31 @@
 # Logs
 logs/
 *.log
- 
+
 # Python
 __pycache__/
 *.py[cod]
 *$py.class
 *.so
 .Python
- 
+
 # Virtual Environment
 venv/
 env/
 ENV/
- 
+
 # IDE specific files
 .idea/
 .vscode/
 *.swp
 *.swo
- 
+
 # OS specific files
 .DS_Store
 Thumbs.db
- 
+
 # Generated files
 recommended_*.txt
+
+.env
+.envrc

--- a/README.md
+++ b/README.md
@@ -217,10 +217,9 @@ python scanner.py -u --date "04/20/2025"
    export FINNHUB_API_KEY="your_api_key_here"
    ```
 
-   For persistent use, add to your shell profile (~/.bashrc, ~/.zshrc, etc.):
-   ```bash
-   echo 'export FINNHUB_API_KEY="your_api_key_here"' >> ~/.bashrc  # Or ~/.zshrc
-   source ~/.bashrc  # Or ~/.zshrc
+   For persistent use, copy .env.example to .env and add your API key:
+   ```dotenv
+    FINNHUB_API_KEY=<your_api_key_here>
    ```
 
 ### Using All Data Sources

--- a/cli_scanner/requirements.txt
+++ b/cli_scanner/requirements.txt
@@ -11,3 +11,4 @@ yahooquery>=2.3.7
 webdriver-manager>=4.0.0
 mysql-connector-python>=8.2.0
 curl_cffi==0.10.0
+python-dotenv>=1.1.0

--- a/cli_scanner/scanner.py
+++ b/cli_scanner/scanner.py
@@ -9,10 +9,14 @@ import logging
 import sys
 import time
 from datetime import datetime, timezone
-
+from dotenv import load_dotenv
+ 
 from utils.logging_utils import setup_logging
 from core.scanner import EarningsScanner
 from utils.discord_webhook import send_webhook
+
+
+load_dotenv()
 
 def main():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Instead of polluting global environment with Finnhub API key, I've added `dotenv` integration that loads the environment from a `.env` file